### PR TITLE
fix the secret of ks-versions

### DIFF
--- a/kubekey-v1.2.1-rc.1.yaml
+++ b/kubekey-v1.2.1-rc.1.yaml
@@ -14,7 +14,9 @@ spec:
       branch: master
       name: ks-versions
       provider: github
-    secret: {}
+    secret:
+      name: linuxsuren-bot
+      namespace: ks-releaser-system
   phase: ready
   repositories:
   - action: pre-release


### PR DESCRIPTION
release-bot does not have the permission of ks-version, but linuxsuren-bot does