### PR TITLE
release ks v0.0.59

### DIFF
--- a/ks-v0.0.59.yaml
+++ b/ks-v0.0.59.yaml
@@ -15,7 +15,7 @@ spec:
       name: ks-versions
       provider: github
     secret: {}
-  phase: draft
+  phase: ready
   repositories:
   - action: release
     address: https://github.com/kubesphere-sigs/ks


### PR DESCRIPTION
ks CLI cannot install KubeSphere via kk due to the wrong usage of the Kubernetes. See the details from https://github.com/kubesphere-sigs/ks/pull/242

Considering that is a serious bug, I request to have a new release.

/cc @kubesphere-sigs/sig-devops 