### PR TITLE
release ks-devops v3.2.1-rc.2

### DIFF
--- a/ks-devops-v3.2.1-rc.2.yaml
+++ b/ks-devops-v3.2.1-rc.2.yaml
@@ -15,7 +15,7 @@ spec:
       name: ks-versions
       provider: github
     secret: {}
-  phase: draft
+  phase: ready
   repositories:
   - action: pre-release
     address: https://github.com/kubesphere/ks-devops


### PR DESCRIPTION
please make sure the upstream PR https://github.com/kubesphere/ks-devops/pull/399 merged before you give it a `/lgtm`

/approve