### PR TITLE
release ks-devops v3.2.1-rc.3

### DIFF
--- a/ks-devops-v3.2.1-rc.3.yaml
+++ b/ks-devops-v3.2.1-rc.3.yaml
@@ -15,7 +15,7 @@ spec:
       name: ks-versions
       provider: github
     secret: {}
-  phase: draft
+  phase: ready
   repositories:
   - action: pre-release
     address: https://github.com/kubesphere/ks-devops


### PR DESCRIPTION
This release is going to check if the container image tag name have the prefix `v`

/cc @kubesphere-sigs/sig-devops 